### PR TITLE
Testing ServletCommon

### DIFF
--- a/EnglishValidation/src/Testing/ServletCommonCoverage.java
+++ b/EnglishValidation/src/Testing/ServletCommonCoverage.java
@@ -1,0 +1,209 @@
+package Testing;
+
+import static org.junit.Assert.assertEquals;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import controller.DbConnection;
+import controller.ServletCommon;
+
+public class ServletCommonCoverage {
+	
+	public class MockObject {
+		public MockObject (String email, String password) {
+			this.email = email;
+			this.password = password;
+		}
+		
+		public void setRequest (MockHttpServletRequest request) {
+			request.addParameter("email", email);
+	        request.addParameter("password", password);
+		} 
+		
+		private String email;
+		private String password;
+	}
+	
+    private ServletCommon servlet;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+
+    
+    Connection conn = DbConnection.getInstance().getConn();
+    String sql = "";
+    PreparedStatement stmt = null;
+    
+    @Before
+    public void setUp() throws SQLException {
+        servlet = new ServletCommon();
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+        
+        sql = "SELECT * FROM user  WHERE EMAIL = 'p.prova@studenti.unisa.it';";
+        stmt = conn.prepareStatement(sql);
+        ResultSet resultSet = stmt.executeQuery();
+        if(!resultSet.isBeforeFirst()) 
+        {
+        	sql = "INSERT INTO user VALUES ('p.prova@studenti.unisa.it', 'Thomas', 'Amendola', 'M', 'Gi230198', 0);";
+            stmt = conn.prepareStatement(sql);
+            stmt.executeUpdate();
+        }  
+    }
+    
+    @Test
+    public void coverage4() throws Exception {
+    	
+    	MockHttpServletRequest request = new MockHttpServletRequest();  
+        MockHttpServletResponse response = new MockHttpServletResponse();  
+        MockObject x = new MockObject("", "");
+        
+        x.setRequest(request);
+    	
+        request.setParameter("flag", "1");
+        
+    	servlet.doPost(request, response);
+
+        assertEquals("json", response.getContentType());
+    }
+    
+    @Test
+    public void coverage1() throws Exception {
+    	
+    	MockHttpServletRequest request = new MockHttpServletRequest();  
+        MockHttpServletResponse response = new MockHttpServletResponse();  
+        MockObject x = new MockObject("p.prova@studenti.unisa.it", "Gi230198");
+        
+        x.setRequest(request);
+    	
+        request.setParameter("flag", "1");
+        
+    	servlet.doPost(request, response);
+
+        assertEquals("json", response.getContentType());
+    }
+    
+    @Test
+    public void coverage2() throws Exception {
+    	
+    	MockHttpServletRequest request = new MockHttpServletRequest();  
+        MockHttpServletResponse response = new MockHttpServletResponse();  
+        MockObject x = new MockObject("segreteria@unisa.it", "password");
+        
+        x.setRequest(request);
+    	
+        request.setParameter("flag", "1");
+        
+    	servlet.doPost(request, response);
+
+        assertEquals("json", response.getContentType());
+    }
+    
+    @Test
+    public void coverage3() throws Exception {
+    	
+    	MockHttpServletRequest request = new MockHttpServletRequest();  
+        MockHttpServletResponse response = new MockHttpServletResponse();  
+        MockObject x = new MockObject("fferrucci@unisa.it", "password");
+        
+        x.setRequest(request);
+    	
+        request.setParameter("flag", "1");
+        
+    	servlet.doPost(request, response);
+
+        assertEquals("json", response.getContentType());
+    }
+    
+    @Test
+    public void coverage5() throws Exception {
+
+    	sql = "DELETE FROM user WHERE EMAIL = 'p.prova2@studenti.unisa.it';";
+        stmt = conn.prepareStatement(sql);
+        stmt.executeUpdate();
+    	
+    	sql = "INSERT INTO user VALUES ('p.prova2@studenti.unisa.it', 'Thomas', 'Amendola', 'M', 'dfab23abcd54ff99d6e668a9fb9c977d352228b8', 0, '2100-09-01');";
+        stmt = conn.prepareStatement(sql);
+        stmt.executeUpdate();
+    	
+    	MockHttpServletRequest request = new MockHttpServletRequest();  
+        MockHttpServletResponse response = new MockHttpServletResponse();  
+        MockObject x = new MockObject("p.prova2@studenti.unisa.it", "Gi230198");
+        
+        x.setRequest(request);
+    	
+        request.setParameter("flag", "1");
+        
+    	servlet.doPost(request, response);
+
+        assertEquals("json", response.getContentType());
+        
+    }
+    
+    @Test
+    public void coverage6() throws Exception {
+    	
+    	MockHttpServletRequest request = new MockHttpServletRequest();  
+        MockHttpServletResponse response = new MockHttpServletResponse();  
+        
+    	
+        request.setParameter("flag", "2");
+        request.setParameter("idUser", "p.prova@studenti.unisa.it");
+        request.setParameter("newName", "Thomas");
+    	servlet.doPost(request, response);
+
+        assertEquals("json", response.getContentType());
+    }
+    
+    @Test
+    public void coverage7() throws Exception {
+    	
+    	MockHttpServletRequest request = new MockHttpServletRequest();  
+        MockHttpServletResponse response = new MockHttpServletResponse();  
+        
+    	
+        request.setParameter("flag", "2");
+        request.setParameter("idUser", "p.prova3@studenti.unisa.it");
+        request.setParameter("newName", "Thomas");
+    	servlet.doPost(request, response);
+
+        assertEquals("json", response.getContentType());
+    }
+    
+    @Test
+    public void coverage8() throws Exception {
+    	
+    	MockHttpServletRequest request = new MockHttpServletRequest();  
+        MockHttpServletResponse response = new MockHttpServletResponse();  
+        
+    	
+        request.setParameter("flag", "3");
+        request.setParameter("idUser", "p.prova@studenti.unisa.it");
+        request.setParameter("newSurname", "Amendola");
+    	servlet.doPost(request, response);
+
+        assertEquals("json", response.getContentType());
+    }
+    
+    @Test
+    public void coverage9() throws Exception {
+    	
+    	MockHttpServletRequest request = new MockHttpServletRequest();  
+        MockHttpServletResponse response = new MockHttpServletResponse();  
+        
+    	
+        request.setParameter("flag", "3");
+        request.setParameter("idUser", "p.prova3@studenti.unisa.it");
+        request.setParameter("newSurname", "Amendola");
+    	servlet.doPost(request, response);
+
+        assertEquals("json", response.getContentType());
+    }
+}

--- a/EnglishValidation/src/Testing/ServletCommonTest.java
+++ b/EnglishValidation/src/Testing/ServletCommonTest.java
@@ -1,14 +1,280 @@
 package Testing;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
-import org.junit.jupiter.api.Test;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 
-class ServletCommonTest {
+import javax.servlet.ServletException;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import Testing.ServletCommonCoverage.MockObject;
+import controller.DbConnection;
+import controller.ServletStudent;
+import controller.ServletCommon;
+
+public class ServletCommonTest {
+	
+	public class MockObject {
+		public MockObject (String email, String password) {
+			this.email = email;
+			this.password = password;
+		}
+		
+		public void setRequest (MockHttpServletRequest request) {
+			request.addParameter("email", email);
+	        request.addParameter("password", password);
+		} 
+		
+		private String email;
+		private String password;
+	}
+	
+    private ServletCommon servlet;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+
+    
+    Connection conn = DbConnection.getInstance().getConn();
+    String sql = "";
+    PreparedStatement stmt = null;
+	
+    @Before
+    public void setUp() throws SQLException {
+    	
+        servlet = new ServletCommon();
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+        
+    }
+    
 	@Test
-	//sdasdaasdaa
-	void test() {
-		fail("Not yet implemented");
+	public void tc_Common_1() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();  
+        MockHttpServletResponse response = new MockHttpServletResponse();  
+        MockObject x = new MockObject("sbagliato", "Gi230198");
+        
+        x.setRequest(request);
+    	
+        request.setParameter("flag", "1");
+        
+        new ServletCommon().doPost(request, response);
+        
+        assertEquals(true, response.getContentAsString().contains("Username o Password errati."));
+	}
+	
+	@Test
+	public void tc_Common_2() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();  
+        MockHttpServletResponse response = new MockHttpServletResponse();  
+        MockObject x = new MockObject("p.prova@studenti.unisa.it", "sbagliato");
+        
+        x.setRequest(request);
+    	
+        request.setParameter("flag", "1");
+        
+        new ServletCommon().doPost(request, response);
+        
+        assertEquals(true, response.getContentAsString().contains("Username o Password errati."));
+	}
+	
+	@Test
+	public void tc_Common_3() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();  
+        MockHttpServletResponse response = new MockHttpServletResponse();  
+        MockObject x = new MockObject("p.prova@studenti.unisa.it", "Gi230198");
+        
+        x.setRequest(request);
+    	
+        request.setParameter("flag", "1");
+        
+        new ServletCommon().doPost(request, response);
+        
+        assertEquals("json", response.getContentType());
+	}
+	
+	@Test
+	public void tc_Common_4() throws Exception {
+		
+		sql = "DELETE FROM user WHERE EMAIL = 'p.prova2@studenti.unisa.it';";
+        stmt = conn.prepareStatement(sql);
+        stmt.executeUpdate();
+    	
+    	sql = "INSERT INTO user VALUES ('p.prova2@studenti.unisa.it', 'Thomas', 'Amendola', 'M', 'dfab23abcd54ff99d6e668a9fb9c977d352228b8', 0, '2100-09-01');";
+        stmt = conn.prepareStatement(sql);
+        stmt.executeUpdate();
+		
+		MockHttpServletRequest request = new MockHttpServletRequest();  
+        MockHttpServletResponse response = new MockHttpServletResponse();  
+        MockObject x = new MockObject("p.prova2@studenti.unisa.it", "Gi230198");
+        
+        x.setRequest(request);
+    	
+        request.setParameter("flag", "1");
+        
+        new ServletCommon().doPost(request, response);
+        
+        assertEquals(true, response.getContentAsString().contains("/banned.jsp"));
+	}
+	
+	@Test
+	public void tc_Common_5() throws Exception {
+
+		MockHttpServletRequest request = new MockHttpServletRequest();  
+        MockHttpServletResponse response = new MockHttpServletResponse();  
+    	
+        request.setParameter("flag", "2");
+        request.setParameter("idUser", "");
+        request.setParameter("newName", "Thomas");
+        
+        new ServletCommon().doPost(request, response);
+        
+        assertEquals(true, response.getContentAsString().contains("Errore aggiornamento Nome."));
+	}
+	
+	@Test
+	public void tc_Common_6() throws Exception {
+
+		MockHttpServletRequest request = new MockHttpServletRequest();  
+        MockHttpServletResponse response = new MockHttpServletResponse();  
+    	
+        request.setParameter("flag", "2");
+        request.setParameter("idUser", "p.prova@studenti.unisa.it");
+        request.setParameter("newName", "");
+        
+        IllegalArgumentException e = Assertions.assertThrows(IllegalArgumentException.class, () -> new ServletCommon().doPost(request, response));
+        
+        if(e == null) fail (); else Assert.assertEquals("Formato non corretto", e.getMessage());
+	}
+	
+	@Test
+	public void tc_Common_7() throws Exception {
+
+		MockHttpServletRequest request = new MockHttpServletRequest();  
+        MockHttpServletResponse response = new MockHttpServletResponse();  
+    	
+        request.setParameter("flag", "2");
+        request.setParameter("idUser", "p.prova@studenti.unisa.it");
+        request.setParameter("newName", ".//&&%%?^");
+        
+        IllegalArgumentException e = Assertions.assertThrows(IllegalArgumentException.class, () -> new ServletCommon().doPost(request, response));
+        
+        if(e == null) fail (); else Assert.assertEquals("Formato non corretto", e.getMessage());
+	}
+	
+	@Test
+	public void tc_Common_8() throws Exception {
+
+		MockHttpServletRequest request = new MockHttpServletRequest();  
+        MockHttpServletResponse response = new MockHttpServletResponse();  
+    	
+        request.setParameter("flag", "2");
+        request.setParameter("idUser", "p.prova@studenti.unisa.it");
+        request.setParameter("newName", "Thomasssssssssssssssssssssssssssssssss");
+        
+        IllegalArgumentException e = Assertions.assertThrows(IllegalArgumentException.class, () -> new ServletCommon().doPost(request, response));
+        
+        if(e == null) fail (); else Assert.assertEquals("Formato non corretto", e.getMessage());
+	}
+	
+	@Test
+	public void tc_Common_9() throws Exception {
+
+		MockHttpServletRequest request = new MockHttpServletRequest();  
+        MockHttpServletResponse response = new MockHttpServletResponse();  
+    	
+        request.setParameter("flag", "2");
+        request.setParameter("idUser", "p.prova@studenti.unisa.it");
+        request.setParameter("newName", "Thomas");
+        
+        new ServletCommon().doPost(request, response);
+        
+        assertEquals("json", response.getContentType());
+	}
+	
+	@Test
+	public void tc_Common_10() throws Exception {
+
+		MockHttpServletRequest request = new MockHttpServletRequest();  
+        MockHttpServletResponse response = new MockHttpServletResponse();  
+    	
+        request.setParameter("flag", "3");
+        request.setParameter("idUser", "");
+        request.setParameter("newSurname", "Amendola");
+        
+        new ServletCommon().doPost(request, response);
+        
+        assertEquals(true, response.getContentAsString().contains("Errore aggiornamento Cognome."));
+	}
+	
+	@Test
+	public void tc_Common_11() throws Exception {
+
+		MockHttpServletRequest request = new MockHttpServletRequest();  
+        MockHttpServletResponse response = new MockHttpServletResponse();  
+    	
+        request.setParameter("flag", "3");
+        request.setParameter("idUser", "p.prova@studenti.unisa.it");
+        request.setParameter("newSurname", "");
+        
+        IllegalArgumentException e = Assertions.assertThrows(IllegalArgumentException.class, () -> new ServletCommon().doPost(request, response));
+        
+        if(e == null) fail (); else Assert.assertEquals("Formato non corretto", e.getMessage());
+	}
+	
+	@Test
+	public void tc_Common_12() throws Exception {
+
+		MockHttpServletRequest request = new MockHttpServletRequest();  
+        MockHttpServletResponse response = new MockHttpServletResponse();  
+    	
+        request.setParameter("flag", "3");
+        request.setParameter("idUser", "p.prova@studenti.unisa.it");
+        request.setParameter("newSurname", ".//&&%%?^");
+        
+        IllegalArgumentException e = Assertions.assertThrows(IllegalArgumentException.class, () -> new ServletCommon().doPost(request, response));
+        
+        if(e == null) fail (); else Assert.assertEquals("Formato non corretto", e.getMessage());
+	}
+	
+	@Test
+	public void tc_Common_13() throws Exception {
+
+		MockHttpServletRequest request = new MockHttpServletRequest();  
+        MockHttpServletResponse response = new MockHttpServletResponse();  
+    	
+        request.setParameter("flag", "3");
+        request.setParameter("idUser", "p.prova@studenti.unisa.it");
+        request.setParameter("newSurname", "Amendolaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        
+        IllegalArgumentException e = Assertions.assertThrows(IllegalArgumentException.class, () -> new ServletCommon().doPost(request, response));
+        
+        if(e == null) fail (); else Assert.assertEquals("Formato non corretto", e.getMessage());
+	}
+	
+	@Test
+	public void tc_Common_14() throws Exception {
+
+		MockHttpServletRequest request = new MockHttpServletRequest();  
+        MockHttpServletResponse response = new MockHttpServletResponse();  
+    	
+        request.setParameter("flag", "3");
+        request.setParameter("idUser", "p.prova@studenti.unisa.it");
+        request.setParameter("newSurname", "Amendola");
+        
+        new ServletCommon().doPost(request, response);
+        
+        assertEquals("json", response.getContentType());
 	}
 
 }

--- a/EnglishValidation/src/controller/ServletCommon.java
+++ b/EnglishValidation/src/controller/ServletCommon.java
@@ -7,6 +7,9 @@ import java.sql.Connection;
 import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
@@ -140,7 +143,16 @@ public class ServletCommon extends HttpServlet {
       } else if (flag == 2) { // Aggiornamento Nome
         String idUser = request.getParameter("idUser");
         String newName = request.getParameter("newName");
+        
+        Pattern p = Pattern.compile("[^a-z0-9 ]", Pattern.CASE_INSENSITIVE);
+        Matcher m = p.matcher(newName);
+        boolean b = m.find();
 
+        
+        if (newName.length() == 0 || newName.length() > 20 || b == true) {
+            throw new IllegalArgumentException("Formato non corretto");
+        }
+        
         try {
           sql = "UPDATE user SET name = ? WHERE email = ?";
           stmt = conn.prepareStatement(sql);
@@ -165,6 +177,14 @@ public class ServletCommon extends HttpServlet {
       } else if (flag == 3) { // Aggiornamento Cognome
         String idUser = request.getParameter("idUser");
         String newSurname = request.getParameter("newSurname");
+        
+        Pattern p = Pattern.compile("[^a-z0-9 ]", Pattern.CASE_INSENSITIVE);
+        Matcher m = p.matcher(newSurname);
+        boolean b = m.find();
+        
+        if (newSurname.length() == 0 || newSurname.length() > 20 || b == true) {
+            throw new IllegalArgumentException("Formato non corretto");
+        }
 
         try {
           sql = "UPDATE user SET surname = ? WHERE email = ?";


### PR DESCRIPTION
Testing White Box + Black Box della ServletCommon

Risultati:
raggiunto il 77.8% di coverage
fixati bugs inerenti alle funzionalità per aggiornare nome e/o cognome
- non è possibile più cambiare il nome o cognome con una stringa vuota
- non è più possibile l'utilizzo di caratteri speciali nei nuovi nomi o cognomi
- non è possibile usare un nome o un cognome che sia più lungo di 20 caratteri

le scelte di sopra sono state fatte seguendo i controlli che vengono già svolti nel momento del registo, motivo per il quale era illogico non averli anche nel caso di cambiamento dei dati